### PR TITLE
Adding JSON serialization to memory cache as a default to match redis handling

### DIFF
--- a/cache/options.go
+++ b/cache/options.go
@@ -19,6 +19,7 @@ type cacheOptions struct {
 	KeyPrefix          string
 	Loader             func(ctx context.Context, key string) (any, error)
 	Instrumenter       instrumenter.Instrumenter
+	MemoryRaw          bool
 }
 
 // Option for the cache instance.
@@ -122,4 +123,12 @@ type Instrumenter instrumenter.Instrumenter
 
 func (i Instrumenter) applyCache(c *cacheOptions) {
 	c.Instrumenter = instrumenter.Instrumenter(i)
+}
+
+// MemoryRaw disables JSON serialization for memory cache if set to true.
+// Default behavior without this option is to JSON serialize values, matching Redis cache behavior.
+type MemoryRaw bool
+
+func (m MemoryRaw) applyCache(c *cacheOptions) {
+	c.MemoryRaw = bool(m)
 }


### PR DESCRIPTION
Serializing the data before storage would fix the issues described and documented here: https://github.com/azugo/core/issues/14, https://github.com/azugo/azugo/issues/20

Benefits:
- the implementations are more unified. By default, both memory cache and redis cache behave identically and can be swapped with no impact regardless of implementation
- Avoids bugs with aliased values changing their underlying value
- generally more reliable

Drawbacks:
- By default, it's no longer possible to store non-serializable data (which redis couldn't do regardless)
- The serialization is slower, uses more cpu cycles and memory

For specific use cases where speed is of upmost importance, the developer still has an option to disable the serialization for the memory cache